### PR TITLE
Missing X_train Parameter in pyexplainer_pyexplainer.py

### DIFF
--- a/pyexplainer/pyexplainer_pyexplainer.py
+++ b/pyexplainer/pyexplainer_pyexplainer.py
@@ -441,7 +441,7 @@ class PyExplainer:
         VIF_threshold : :obj:`int`
             Threshold value of VIF score.
         """
-        X_AS_train = AutoSpearman(correlation_threshold, correlation_method, VIF_threshold)
+        X_AS_train = AutoSpearman(self.X_train, correlation_threshold, correlation_method, VIF_threshold)
         if apply_to_X_train:
             self.set_X_train(X_AS_train)
             # if there is data of full feature names


### PR DESCRIPTION
I tried using autoSpearman and got X_train undefined.

Calling

pyExplainer = pyexplainer_pyexplainer.PyExplainer(X_train=trainFeatureDf, y_train=trainY, indep=trainFeatureDf.columns, dep=field.LABEL, blackbox_model=model, class_label=[False, True])
pyExplainer.auto_spearman()

OB:
`Traceback (most recent call last):
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3437, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-41-afb133d285d2>", line 1, in <module>
    pyExplainer.auto_spearman()
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/pyexplainer/pyexplainer_pyexplainer.py", line 444, in auto_spearman
    X_AS_train = AutoSpearman(X_train, correlation_threshold, correlation_method, VIF_threshold)
NameError: name 'X_train' is not defined`