### PR TITLE
Calculating vif_scores resulting in error because X_AS_train.values is an array of object

### DIFF
--- a/pyexplainer/pyexplainer_pyexplainer.py
+++ b/pyexplainer/pyexplainer_pyexplainer.py
@@ -98,7 +98,7 @@ def AutoSpearman(X_train, correlation_threshold=0.7, correlation_method='spearma
     count = 1
     while True:
         # Calculate VIF scores
-        vif_scores = pd.DataFrame([variance_inflation_factor(X_AS_train.values, i)
+        vif_scores = pd.DataFrame([variance_inflation_factor(np.array(X_AS_train.values, dtype=float), i)
                                    for i in range(X_AS_train.shape[1])],
                                   index=X_AS_train.columns)
         # Prepare a final dataframe of VIF scores


### PR DESCRIPTION
Error at def AutoSpearman line 101

variance_inflation_factor must be called nparray of any type that is not object.
However, the lib send nparray of object (X_AS_train.values).
I'm not sure why and whether it is only happened on my case.  :(

I fix on my local as in diff and it runs fine.


OB: call 
pyExplainer = pyexplainer_pyexplainer.PyExplainer(X_train=trainFeatureDf, y_train=trainY, indep=trainFeatureDf.columns, dep=field.LABEL, blackbox_model=model, class_label=[False, True])
pyExplainer.auto_spearman()

Return Stacktraces:

Traceback (most recent call last):
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/pydevd.py", line 1483, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/jpasuksmit/agile-requirement/model/TestPyExplainer.py", line 48, in <module>
    pyExplainer.auto_spearman()
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/pyexplainer/pyexplainer_pyexplainer.py", line 444, in auto_spearman
    X_AS_train = AutoSpearman(self.X_train, correlation_threshold, correlation_method, VIF_threshold)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/pyexplainer/pyexplainer_pyexplainer.py", line 101, in AutoSpearman
    vif_scores = pd.DataFrame([variance_inflation_factor(np.array(X_AS_train.values, dtype=float), i)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/pyexplainer/pyexplainer_pyexplainer.py", line 101, in <listcomp>
    vif_scores = pd.DataFrame([variance_inflation_factor(np.array(X_AS_train.values, dtype=float), i)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/stats/outliers_influence.py", line 192, in variance_inflation_factor
    r_squared_i = OLS(x_i, x_noti).fit().rsquared
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/regression/linear_model.py", line 872, in __init__
    super(OLS, self).__init__(endog, exog, missing=missing,
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/regression/linear_model.py", line 703, in __init__
    super(WLS, self).__init__(endog, exog, missing=missing,
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/regression/linear_model.py", line 190, in __init__
    super(RegressionModel, self).__init__(endog, exog, **kwargs)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/model.py", line 237, in __init__
    super(LikelihoodModel, self).__init__(endog, exog, **kwargs)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/model.py", line 77, in __init__
    self.data = self._handle_data(endog, exog, missing, hasconst,
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/model.py", line 101, in _handle_data
    data = handle_data(endog, exog, missing, hasconst, **kwargs)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/data.py", line 672, in handle_data
    return klass(endog, exog=exog, missing=missing, hasconst=hasconst,
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/data.py", line 87, in __init__
    self._handle_constant(hasconst)
  File "/Users/jpasuksmit/anaconda3/envs/agile-requirement/lib/python3.8/site-packages/statsmodels/base/data.py", line 132, in _handle_constant
    if not np.isfinite(exog_max).all():
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

